### PR TITLE
Check if previous values are undefined, rather than evaluated as false

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,10 +17,10 @@ function raf (t, force) {
   vh = window.innerHeight
   vw = window.innerWidth
 
-  if (!px) px = x
-  if (!py) py = y
-  if (!pvw) pvw = vw
-  if (!pvh) pvh = vh
+  if (px === undefined) px = x
+  if (py === undefined) py = y
+  if (pvw === undefined) pvw = vw
+  if (pvh === undefined) pvh = vh
 
   if (
     force ||


### PR DESCRIPTION
In the course of using srraf to trigger an event when the user scrolls down from the top of the page, i noticed that `py` is never equal to `0` even when `y` was equal to `0` in the previous function call. 

For instance, if the user is at the top of the page (`y = 0`) and scrolls down, say to `y = 4`, `py` should equal `0` and `y` should equal `4`. The actual behavior in this case is that both `py` and `y` are `4`.

I think this is because `if (!py) py = y`. The `!py` condition is met when `py`  is legitimately `0` 